### PR TITLE
only set tty_name when a tty is used

### DIFF
--- a/pynentry.py
+++ b/pynentry.py
@@ -98,10 +98,12 @@ class PynEntry(metaclass=PinMeta):
         valid = ["OK Your orders please\n", "OK Pleased to meet you\n"]
         assert resp in valid
 
+        self.tty_name = None
         try:
-            self.tty_name = os.ttyname(sys.stdout.fileno())
+            if sys.stdout.isatty():
+                self.tty_name = os.ttyname(sys.stdout.fileno())
         except AttributeError:  # We are on windows
-            self.tty_name = None
+            pass
         self.locale = '{}.{}'.format(*locale.getlocale())
         self.last_cmd = ''
 


### PR DESCRIPTION
only set tty_name when a tty is used, without these changes it isn't possible to use pynentry without a tty (`OSError: [Errno 25] Inappropriate ioctl for device` is raised).

The following code will show the error:
```python
import subprocess
print(subprocess.check_output(["python3", "./test.py"]))
```

* Use `self.tty_name = None` as a default
* Only try to get `os.ttyname` when `sys.stdout.isatty()`.